### PR TITLE
Addition of Postgres

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,11 @@ Vagrant.configure(2) do |config|
         #setup project directory
         config.vm.synced_folder ".", "/home/vagrant/obulamu"
 
-        #Run provision script to isntall requirements
+        #Run provision script to install requirements
         config.vm.provision "shell", path: "provision-script.sh"
+
+        #Initialize postgres DB
+        config.vm.provision "shell", path: "initialize-postgres.sh"
 
         # Create a forwarded port mapping which allows access to a specific port
         # within the machine from a port on the host machine
@@ -16,5 +19,7 @@ Vagrant.configure(2) do |config|
         config.vm.network :forwarded_port, guest: 8000, host: 8000 
         #Port for App
         config.vm.network :forwarded_port, guest: 8080, host: 8080
+
+        config.vm.provision "shell", inline: "echo Server Provisioned..."
 
 end

--- a/initialize-postgres.sh
+++ b/initialize-postgres.sh
@@ -1,0 +1,36 @@
+#Create and initalize the PostgresDB and its user for Obulamu
+
+#! /bin/bash
+#Reload profile environmental variables
+source ~/.profile
+
+postgresCmd() {
+	echo $SQL
+	sudo su postgres bash -c "psql -c \"$SQL\""
+}
+
+
+echo "Creating DATABASE..."
+SQL="CREATE DATABASE $DATABASE_NAME;"
+postgresCmd $SQL 
+
+
+echo "Creating User..."
+sudo su postgres bash -c "psql -c 'CREATE USER $DATABASE_USER WITH PASSWORD '\''$DATABASE_PASSWORD'\'';'"
+
+echo "Altering Roles..."
+SQL="ALTER ROLE $DATABASE_USER SET client_encoding TO 'utf8';"
+postgresCmd $SQL
+SQL="ALTER ROLE $DATABASE_USER SET default_transaction_isolation TO 'read committed';"
+postgresCmd $SQL
+SQL="ALTER ROLE $DATABASE_USER SET timezone TO 'UTC';"
+postgresCmd $SQL
+
+SQL="GRANT ALL PRIVILEGES ON DATABASE $DATABASE_NAME TO $DATABASE_USER;"
+postgresCmd $SQL
+
+#Make migrations and migrate
+echo "Inital Django DB migrations..."
+cd /home/vagrant/obulamu
+python manage.py makemigrations
+python manage.py migrate

--- a/provision-script.sh
+++ b/provision-script.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash 
 
 #change cur dir to the code's home directory 
 cd /home/vagrant/obulamu

--- a/provision-script.sh
+++ b/provision-script.sh
@@ -8,14 +8,23 @@ echo "Provision Vagrant Box..."
 echo "Update apt-get..."
 sudo apt-get update
 
-#Install and update pip
-echo "Installing pip..."
-yes | sudo apt-get install python-pip
-sudo pip install --upgrade pip
+#set postgres Env Vars for vagrant user
+echo "Setup environment variables..."
+echo "export DATABASE_NAME=obulamu">>/home/vagrant/.profile
+echo "export DATABASE_USER=dbadmin">>/home/vagrant/.profile
+echo "export DATABASE_PASSWORD=easypassword">>/home/vagrant/.profile
 
-#Install requirements
-echo "Installing project requirements.txt..."
-pip install -r requirements.txt
+#set postgres Env Vars for root user
+echo "export DATABASE_NAME=obulamu">>~/.profile
+echo "export DATABASE_USER=dbadmin">>~/.profile
+echo "export DATABASE_PASSWORD=easypassword">>~/.profile
+
+#reload profile variables
+source ~/.profile
+
+#install postgres system requirememnts
+echo "Installing Postgres system packages..."
+sudo apt-get -y install python-pip python-dev libpq-dev postgresql postgresql-contrib
 
 #Install node and npm
 echo "Installing node and npm..."
@@ -23,11 +32,11 @@ curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 sudo apt-get install -y nodejs
 npm install
 
-#Make migrations and migrate
-echo "Inital Django DB migrations..."
-python manage.py makemigrations
-python manage.py migrate
+#Install and update pip
+echo "Installing and updating pip..."
+yes | sudo apt-get install python-pip
+sudo pip install --upgrade pip
 
-echo "Server Provisioned..."
-
-echo "run 'vagrant ssh' to enter the VM"
+#Install python project requirements
+echo "Installing project requirements.txt..."
+pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.10.3
 django-cors-headers==1.3.1
 djangorestframework==3.5.3
+psycopg2==2.6.2

--- a/server/settings.py
+++ b/server/settings.py
@@ -79,9 +79,13 @@ WSGI_APPLICATION = 'server.wsgi.application'
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+	'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.environ.get('DATABASE_NAME', ''),
+        'USER': os.environ.get('DATABASE_USER', ''),
+        'PASSWORD': os.environ.get('DATABASE_PASSWORD', ''),
+        'HOST': 'localhost',
+        'PORT': '',
     }
 }
 


### PR DESCRIPTION
## Issue/Enhancement #1 (substitute sqlite for postgres)
 

- Vagrant provisioning now installs the postgres requirements and sets environment variables for singular reference to db credentials. 
- The script initialize-postgres.sh creates a database and user on the vagrant machine using the environmental variables created in the machine's provisioning. 
- psycopg2==2.6.2 added to requirements for python <-> postgres compatibility 

If vagrant is already provisioned on your machine you may need to run `vagrant up --provision` to re provision your box. 